### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/conformance-suites/1.0.2/conformance/ogles/process-ogles2-tests.py
+++ b/conformance-suites/1.0.2/conformance/ogles/process-ogles2-tests.py
@@ -448,7 +448,7 @@ var successfullyParsed = true;
         for uniformElem in uniformElems:
           uniform = {"count": 1}
           for child in uniformElem.childNodes:
-            if child.localName == None:
+            if child.localName is None:
               pass
             elif child.localName == "name":
               uniforms[GetText(child.childNodes)] = uniform

--- a/conformance-suites/1.0.3/conformance/ogles/process-ogles2-tests.py
+++ b/conformance-suites/1.0.3/conformance/ogles/process-ogles2-tests.py
@@ -447,7 +447,7 @@ var successfullyParsed = true;
         for uniformElem in uniformElems:
           uniform = {"count": 1}
           for child in uniformElem.childNodes:
-            if child.localName == None:
+            if child.localName is None:
               pass
             elif child.localName == "name":
               uniforms[GetText(child.childNodes)] = uniform

--- a/resources/html5lib/src/html5lib/filters/inject_meta_charset.py
+++ b/resources/html5lib/src/html5lib/filters/inject_meta_charset.py
@@ -21,7 +21,7 @@ class Filter(_base.Filter):
                    # replace charset with actual encoding
                    has_http_equiv_content_type = False
                    for (namespace,name),value in token["data"].iteritems():
-                       if namespace != None:
+                       if namespace is not None:
                            continue
                        elif name.lower() == u'charset':
                           token["data"][(namespace,name)] = self.encoding

--- a/resources/html5lib/src/html5lib/html5parser.py
+++ b/resources/html5lib/src/html5lib/html5parser.py
@@ -539,8 +539,8 @@ def getPhases(debug):
             systemId = token["systemId"]
             correct = token["correct"]
 
-            if (name != "html" or publicId != None or
-                systemId != None and systemId != "about:legacy-compat"):
+            if (name != "html" or publicId is not None or
+                systemId is not None and systemId != "about:legacy-compat"):
                 self.parser.parseError("unknown-doctype")
 
             if publicId is None:
@@ -615,7 +615,7 @@ def getPhases(debug):
                 or startswithany(publicId,
                     ("-//w3c//dtd html 4.01 frameset//",
                      "-//w3c//dtd html 4.01 transitional//")) and 
-                    systemId == None
+                    systemId is None
                 or systemId and systemId.lower() == "http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd"):
                 self.parser.compatMode = "quirks"
             elif (startswithany(publicId,
@@ -624,7 +624,7 @@ def getPhases(debug):
                   or startswithany(publicId,
                       ("-//w3c//dtd html 4.01 frameset//",
                        "-//w3c//dtd html 4.01 transitional//")) and 
-                      systemId != None):
+                      systemId is not None):
                 self.parser.compatMode = "limited quirks"
 
             self.parser.phase = self.parser.phases["beforeHtml"]

--- a/resources/html5lib/src/html5lib/inputstream.py
+++ b/resources/html5lib/src/html5lib/inputstream.py
@@ -683,7 +683,7 @@ class EncodingParser(object):
                 return "".join(attrName), ""
             elif c in asciiUppercaseBytes:
                 attrName.append(c.lower())
-            elif c == None:
+            elif c is None:
                 return None
             else:
                 attrName.append(c)

--- a/resources/html5lib/src/html5lib/tests/test_parser2.py
+++ b/resources/html5lib/src/html5lib/tests/test_parser2.py
@@ -26,7 +26,7 @@ class MoreParserTests(unittest.TestCase):
   def test_namespace_html_elements_1(self): 
     parser = html5parser.HTMLParser(namespaceHTMLElements=False)
     doc = parser.parse("<html></html>")
-    self.assert_(doc.childNodes[0].namespace == None)
+    self.assert_(doc.childNodes[0].namespace is None)
 
 def buildTestSuite():
   return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/resources/html5lib/src/html5lib/treebuilders/__init__.py
+++ b/resources/html5lib/src/html5lib/treebuilders/__init__.py
@@ -60,7 +60,7 @@ def getTreeBuilder(treeType, implementation=None, **kwargs):
         if treeType == "dom":
             import dom
             # XXX: Keep backwards compatibility by using minidom if no implementation is given
-            if implementation == None:
+            if implementation is None:
                 from xml.dom import minidom
                 implementation = minidom
             # XXX: NEVER cache here, caching is done in the dom submodule
@@ -76,7 +76,7 @@ def getTreeBuilder(treeType, implementation=None, **kwargs):
             treeBuilderCache[treeType] = etree_lxml.TreeBuilder
         elif treeType == "etree":
             # Come up with a sane default
-            if implementation == None:
+            if implementation is None:
                 try:
                     import xml.etree.cElementTree as ET
                 except ImportError:

--- a/resources/html5lib/src/html5lib/treebuilders/dom.py
+++ b/resources/html5lib/src/html5lib/treebuilders/dom.py
@@ -109,7 +109,7 @@ def getDomBuilder(DomImplementation):
             return self.element.hasChildNodes()
 
         def getNameTuple(self):
-            if self.namespace == None:
+            if self.namespace is None:
                 return namespaces["html"], self.name
             else:
                 return self.namespace, self.name
@@ -197,7 +197,7 @@ def getDomBuilder(DomImplementation):
                 rv.append("|%s\"%s\"" %(' '*indent, element.nodeValue))
             else:
                 if (hasattr(element, "namespaceURI") and
-                    element.namespaceURI != None):
+                    element.namespaceURI is not None):
                     name = "%s %s"%(constants.prefixes[element.namespaceURI],
                                     element.nodeName)
                 else:
@@ -239,7 +239,7 @@ def getDomBuilder(DomImplementation):
           for attrname in node.attributes.keys():
             attr = node.getAttributeNode(attrname)
             if (attr.namespaceURI == XMLNS_NAMESPACE or
-               (attr.namespaceURI == None and attr.nodeName.startswith('xmlns'))):
+               (attr.namespaceURI is None and attr.nodeName.startswith('xmlns'))):
               prefix = (attr.nodeName != 'xmlns' and attr.nodeName or None)
               handler.startPrefixMapping(prefix, attr.nodeValue)
               prefixes.append(prefix)
@@ -250,7 +250,7 @@ def getDomBuilder(DomImplementation):
           # apply namespace declarations
           for attrname in node.attributes.keys():
             attr = node.getAttributeNode(attrname)
-            if attr.namespaceURI == None and ':' in attr.nodeName:
+            if attr.namespaceURI is None and ':' in attr.nodeName:
               prefix = attr.nodeName.split(':')[0]
               if nsmap.has_key(prefix):
                 del attributes[(attr.namespaceURI, attr.nodeName)]

--- a/resources/html5lib/src/html5lib/treebuilders/simpletree.py
+++ b/resources/html5lib/src/html5lib/treebuilders/simpletree.py
@@ -71,7 +71,7 @@ class Node(_base.Node):
         return bool(self.childNodes)
 
     def getNameTuple(self):
-        if self.namespace == None:
+        if self.namespace is None:
             return namespaces["html"], self.name
         else:
             return self.namespace, self.name
@@ -175,7 +175,7 @@ class Element(Node):
         self.attributes = {}
 
     def __unicode__(self):
-        if self.namespace == None:
+        if self.namespace is None:
             return u"<%s>" % self.name
         else:
             return u"<%s %s>"%(prefixes[self.namespace], self.name)

--- a/resources/html5lib/src/html5lib/treebuilders/soup.py
+++ b/resources/html5lib/src/html5lib/treebuilders/soup.py
@@ -127,7 +127,7 @@ class Element(_base.Node):
         return self.element.contents
 
     def getNameTuple(self):
-        if self.namespace == None:
+        if self.namespace is None:
             return namespaces["html"], self.name
         else:
             return self.namespace, self.name

--- a/sdk/tests/conformance/ogles/process-ogles2-tests.py
+++ b/sdk/tests/conformance/ogles/process-ogles2-tests.py
@@ -447,7 +447,7 @@ var successfullyParsed = true;
         for uniformElem in uniformElems:
           uniform = {"count": 1}
           for child in uniformElem.childNodes:
-            if child.localName == None:
+            if child.localName is None:
               pass
             elif child.localName == "name":
               uniforms[GetText(child.childNodes)] = uniform


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:WebGL?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:WebGL?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
